### PR TITLE
header.ejs の subtitle を config.yml に存在する subtitle を参照するように変更

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -24,9 +24,9 @@
       <h1 id="logo-wrap">
         <a href="<%- url_for() %>" id="logo"><%= config.title %></a>
       </h1>
-      <% if (theme.subtitle){ %>
+      <% if (config.subtitle){ %>
         <h2 id="subtitle-wrap">
-          <a href="<%- url_for() %>" id="subtitle"><%= theme.subtitle %></a>
+          <a href="<%- url_for() %>" id="subtitle"><%= config.subtitle %></a>
         </h2>
       <% } %>
     </div>


### PR DESCRIPTION
Change header.ejs to use a subtitle in config.yml instead of a one in theme.